### PR TITLE
#12 rate limit

### DIFF
--- a/src/main/java/com/jeanchampemont/wtfdyum/service/impl/TwitterServiceImpl.java
+++ b/src/main/java/com/jeanchampemont/wtfdyum/service/impl/TwitterServiceImpl.java
@@ -85,7 +85,7 @@ public class TwitterServiceImpl implements TwitterService {
         final Set<Long> result = new HashSet<>();
         try {
             IDs followersIDs = null;
-            final long cursor = -1;
+            long cursor = -1;
             do {
                 followersIDs = twitter.getFollowersIDs(userId, cursor);
                 if(followersIDs.hasNext()) {

--- a/src/main/java/com/jeanchampemont/wtfdyum/service/impl/TwitterServiceImpl.java
+++ b/src/main/java/com/jeanchampemont/wtfdyum/service/impl/TwitterServiceImpl.java
@@ -88,9 +88,11 @@ public class TwitterServiceImpl implements TwitterService {
             final long cursor = -1;
             do {
                 followersIDs = twitter.getFollowersIDs(userId, cursor);
-
-                checkRateLimitStatus(followersIDs.getRateLimitStatus(),
+                if(followersIDs.hasNext()) {
+                    cursor = followersIDs.getNextCursor();
+                    checkRateLimitStatus(followersIDs.getRateLimitStatus(),
                         WTFDYUMExceptionType.GET_FOLLOWERS_RATE_LIMIT_EXCEEDED);
+                }
 
                 final Set<Long> currentFollowers = Arrays.stream(followersIDs.getIDs()).boxed()
                         .collect(Collectors.toCollection(() -> new HashSet<>()));

--- a/src/test/java/com/jeanchampemont/wtfdyum/service/TwitterServiceTest.java
+++ b/src/test/java/com/jeanchampemont/wtfdyum/service/TwitterServiceTest.java
@@ -271,6 +271,7 @@ public class TwitterServiceTest {
         when(twitter.getFollowersIDs(444L, -1)).thenReturn(idsMock);
 
         final RateLimitStatus rateLimitStatusMock = mock(RateLimitStatus.class);
+        when(idsMock.hasNext()).thenReturn(true);
         when(idsMock.getRateLimitStatus()).thenReturn(rateLimitStatusMock);
 
         when(rateLimitStatusMock.getRemaining()).thenReturn(0);

--- a/src/test/java/com/jeanchampemont/wtfdyum/service/TwitterServiceTest.java
+++ b/src/test/java/com/jeanchampemont/wtfdyum/service/TwitterServiceTest.java
@@ -131,6 +131,41 @@ public class TwitterServiceTest {
     }
 
     @Test
+    public void getFollowersMultiplePageTest() throws Exception {
+        final Optional<Principal> principal = Optional.of(new Principal(123L, "toktok", "secsecret"));
+        final IDs idsMock = mock(IDs.class);
+        when(twitter.getFollowersIDs(444L, -1)).thenReturn(idsMock);
+
+        final RateLimitStatus rateLimitStatusMock = mock(RateLimitStatus.class);
+        when(idsMock.getRateLimitStatus()).thenReturn(rateLimitStatusMock);
+        when(idsMock.hasNext()).thenReturn(true);
+
+        when(rateLimitStatusMock.getRemaining()).thenReturn(1);
+
+        when(idsMock.getIDs()).thenReturn(new long[]{12L, 34L, 44L, 42L, 42L, 999L});
+
+        when(idsMock.hasNext()).thenReturn(false);
+
+        when(rateLimitStatusMock.getRemaining()).thenReturn(0);
+
+        when(idsMock.getIDs()).thenReturn(new long[]{1001L, 1002L, 1003L});
+
+        final Set<Long> followers = sut.getFollowers(444L, principal);
+
+        assertThat(followers).isNotNull();
+        assertThat(followers.contains(12L));
+        assertThat(followers.contains(34L));
+        assertThat(followers.contains(44L));
+        assertThat(followers.contains(42L));
+        assertThat(followers.contains(999L));
+        assertThat(followers.contains(1001L));
+        assertThat(followers.contains(1002L));
+        assertThat(followers.contains(1003L));
+
+        verify(twitter, times(1)).setOAuthAccessToken(new AccessToken("toktok", "secsecret"));
+    }
+
+    @Test
     public void getFollowersTestWithoutPrincipal() throws Exception {
         final IDs idsMock = mock(IDs.class);
         when(twitter.getFollowersIDs(444L, -1)).thenReturn(idsMock);


### PR DESCRIPTION
- update cursor...
- check rate limit status only when needed

More work is needed:

Tests to be fixed:
- ~~TwitterServiceTest.getFollowersTestWithoutPrincipalRateLimit:279 » NullPointer~~

Tests to be created:
- ~~Test getting multiple page of followers~~
- ~~edge case: test rate limit to be exceeded but no more followers to get (should work)~~
